### PR TITLE
cleanup data logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog Plentymarkets BS Payone Plugin
 
+## v1.0.10 (2020-03-06)
+* Cleaned logging of request and response data
+
 ## v1.0.9 (2018-04-10)
 * Changed user_guide alert Text
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.9",
+  "version": "1.0.10",
   "license":"MIT",
   "pluginIcon":"icon_plugin_xs.png",
   "price":0.0,

--- a/src/Adapter/Logger.php
+++ b/src/Adapter/Logger.php
@@ -53,9 +53,7 @@ class Logger //implements LoggerContract
     public function setIdentifier(string $identifier)
     {
         $this->logger = $this->getLogger($identifier);
-        $this->logger->setReferenceType($this->referenceType);
-        $this->logger->setReferenceValue($this->referenceValue);
-
+        $this->addReference($this->referenceType, $this->referenceValue);
         return $this;
     }
 
@@ -208,32 +206,15 @@ class Logger //implements LoggerContract
 
         return $this;
     }
-
+    
     /**
      * @param string $referenceType
-     *
-     * @return Logger
-     */
-    public function setReferenceType(
-        string $referenceType
-    ) {
-        $this->referenceType = $referenceType;
-        $this->logger->setReferenceType($referenceType);
-
-        return $this;
-    }
-
-    /**
      * @param $referenceValue
-     *
-     * @return Logger
+     * @return $this
      */
-    public function setReferenceValue(
-        $referenceValue
-    ) {
-        $this->referenceValue = $referenceValue;
-        $this->logger->setReferenceValue($referenceValue);
-
+    public function addReference(string $referenceType, $referenceValue)
+    {
+        $this->logger->addReference($referenceType,$referenceValue);
         return $this;
     }
 

--- a/src/Controllers/StatusController.php
+++ b/src/Controllers/StatusController.php
@@ -70,10 +70,9 @@ class StatusController extends Controller
             $txaction = $txaction . '_' . $transactionStatus;
         }
 
-        $this->logger->setIdentifier(__METHOD__);
-        $this->logger->setReferenceType(Logger::PAYONE_REQUEST_REFERENCE);
-        $this->logger->setReferenceValue($txid);
-        $this->logger->critical('Controller.Status', $this->request->all());
+        $this->logger->setIdentifier(__METHOD__)
+            ->addReference(Logger::PAYONE_REQUEST_REFERENCE,$txid);
+        $this->logger->debug('Controller.Status', $this->request->all());
 
         if ($this->request->get('key') != md5($this->config->get('key'))) {
             return;

--- a/src/Services/Api.php
+++ b/src/Services/Api.php
@@ -69,8 +69,8 @@ class Api
         $response = $this->doLibCall((self::REQUEST_TYPE_AUTH), $requestParams);
         $responseObject = AuthResponseFactory::create($response);
 
-        $this->logger->setReferenceValue($responseObject->getTransactionID());
-        $this->logger->critical('Api.' . $this->getCallAction(self::REQUEST_TYPE_AUTH), $response);
+        $this->logger->addReference(Logger::PAYONE_REQUEST_REFERENCE, $responseObject->getTransactionID());
+        $this->logger->debug('Api.' . $this->getCallAction(self::REQUEST_TYPE_AUTH), $response);
 
         return $responseObject;
     }
@@ -88,8 +88,8 @@ class Api
         $response = $this->doLibCall((self::REQUEST_TYPE_PRE_AUTH), $requestParams);
         $responseObject = PreAuthResponseFactory::create($response);
 
-        $this->logger->setReferenceValue($responseObject->getTransactionID());
-        $this->logger->critical('Api.' . $this->getCallAction(self::REQUEST_TYPE_PRE_AUTH), $response);
+        $this->logger->addReference(Logger::PAYONE_REQUEST_REFERENCE, $responseObject->getTransactionID());
+        $this->logger->debug('Api.' . $this->getCallAction(self::REQUEST_TYPE_PRE_AUTH), $response);
 
         return $responseObject;
     }
@@ -108,8 +108,8 @@ class Api
 
         $responseObject = ResponseFactory::create($response);
 
-        $this->logger->setReferenceValue($responseObject->getTransactionID());
-        $this->logger->critical('Api.' . $this->getCallAction(self::REQUEST_TYPE_REVERSAL), $response);
+        $this->logger->addReference(Logger::PAYONE_REQUEST_REFERENCE, $responseObject->getTransactionID());
+        $this->logger->debug('Api.' . $this->getCallAction(self::REQUEST_TYPE_REVERSAL), $response);
 
         return $responseObject;
     }
@@ -128,8 +128,8 @@ class Api
 
         $responseObject = ResponseFactory::create($response);
 
-        $this->logger->setReferenceValue($responseObject->getTransactionID());
-        $this->logger->critical('Api.' . $this->getCallAction(self::REQUEST_TYPE_CAPTURE), $response);
+        $this->logger->addReference(Logger::PAYONE_REQUEST_REFERENCE, $responseObject->getTransactionID());
+        $this->logger->debug('Api.' . $this->getCallAction(self::REQUEST_TYPE_CAPTURE), $response);
 
         return $responseObject;
     }
@@ -148,8 +148,8 @@ class Api
 
         $responseObject = ResponseFactory::create($response);
 
-        $this->logger->setReferenceValue($responseObject->getTransactionID());
-        $this->logger->critical('Api.' . $this->getCallAction(self::REQUEST_TYPE_AUTH), $response);
+        $this->logger->addReference(Logger::PAYONE_REQUEST_REFERENCE, $responseObject->getTransactionID());
+        $this->logger->debug('Api.' . $this->getCallAction(self::REQUEST_TYPE_AUTH), $response);
 
         return $responseObject;
     }
@@ -166,8 +166,8 @@ class Api
 
         $responseObject = ResponseFactory::create($response);
 
-        $this->logger->setReferenceValue($responseObject->getTransactionID());
-        $this->logger->critical('Api.' . $this->getCallAction(self::REQUEST_TYPE_AUTH), $response);
+        $this->logger->addReference(Logger::PAYONE_REQUEST_REFERENCE, $responseObject->getTransactionID());
+        $this->logger->debug('Api.' . $this->getCallAction(self::REQUEST_TYPE_AUTH), $response);
 
         return $responseObject;
     }
@@ -184,8 +184,8 @@ class Api
 
         $responseObject = ResponseFactory::create($response);
 
-        $this->logger->setReferenceValue($responseObject->getTransactionID());
-        $this->logger->critical('Api.' . $this->getCallAction(self::REQUEST_TYPE_AUTH), $response);
+        $this->logger->addReference(Logger::PAYONE_REQUEST_REFERENCE, $responseObject->getTransactionID());
+        $this->logger->debug('Api.' . $this->getCallAction(self::REQUEST_TYPE_AUTH), $response);
 
         return $responseObject;
     }
@@ -202,8 +202,8 @@ class Api
 
         $responseObject = ManagemandateResponseFactory::create($response);
 
-        $this->logger->setReferenceValue($responseObject->getTransactionID());
-        $this->logger->critical('Api.' . $this->getCallAction(self::REQUEST_TYPE_MANAGEMANDATE), $response);
+        $this->logger->addReference(Logger::PAYONE_REQUEST_REFERENCE, $responseObject->getTransactionID());
+        $this->logger->debug('Api.' . $this->getCallAction(self::REQUEST_TYPE_MANAGEMANDATE), $response);
 
         return $responseObject;
     }
@@ -216,8 +216,8 @@ class Api
      */
     public function doLibCall($call, $requestParams): array
     {
-        $this->logger->setReferenceType(Logger::PAYONE_REQUEST_REFERENCE);
-        $this->logger->critical('Api.' . $this->getCallAction($call), $requestParams);
+        $this->logger->addReference(Logger::PAYONE_REQUEST_REFERENCE, Logger::PAYONE_REQUEST_REFERENCE);
+        $this->logger->debug('Api.' . $this->getCallAction($call), $requestParams);
 
         try {
             $response = $this->libCall->call(


### PR DESCRIPTION
@j-konopka @plentymarkets/team-order-payment 

https://plentymarkets.kanbanize.com/ctrl_board/50/cards/98515/details/

- Das Logging der Request und Responses wurde einmal aufgeräumt (debug anstelle von critical)
- Alte Logging-Funktion entfernt, die als deprecated markiert wurde