### PR TITLE
cleanup data logging

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,5 +1,10 @@
 # Release Notes für PAYONE
 
+## 1.1.12 (2020-03-09)
+
+### Geändert
+- Logging des Datenaustausches zur Payone Schnittstelle optimiert.
+
 ## 1.1.11 (2020-03-03)
 
 ### Geändert

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,5 +1,10 @@
 # Release Notes for PAYONE
 
+## 1.1.12 (2020-03-09)
+
+### Geändert
+- Optimized logging of the data transfer with the Payone Api.
+
 ## 1.1.11 (2020-03-03)
 
 ### Changed

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.11",
+  "version": "1.1.12",
   "license":"MIT",
   "pluginIcon":"icon_plugin_xs.png",
   "price":0.0,

--- a/src/Adapter/Logger.php
+++ b/src/Adapter/Logger.php
@@ -53,8 +53,7 @@ class Logger //implements LoggerContract
     public function setIdentifier(string $identifier)
     {
         $this->logger = $this->getLogger($identifier);
-        $this->logger->setReferenceType($this->referenceType);
-        $this->logger->setReferenceValue($this->referenceValue);
+        $this->addReference($this->referenceType, $this->referenceValue);
 
         return $this;
     }
@@ -183,30 +182,17 @@ class Logger //implements LoggerContract
         $this->getPlentyLogger()->logException($exception);
         return $this;
     }
-
+    
     /**
-     * @param string $referenceType
+     * Adds a reference to the current logger instance, for a more understanding log message.
      *
-     * @return Logger
+     * @param   string          $referenceType      The reference type to be added to the log (e.g. orderId)
+     * @param   string          $referenceValue     The reference value for the current log message.
+     * @return $this
      */
-    public function setReferenceType(
-        string $referenceType
-    ) {
-        $this->referenceType = $referenceType;
-        $this->logger->setReferenceType($referenceType);
-        return $this;
-    }
-
-    /**
-     * @param $referenceValue
-     *
-     * @return Logger
-     */
-    public function setReferenceValue(
-        $referenceValue
-    ) {
-        $this->referenceValue = $referenceValue;
-        $this->logger->setReferenceValue($referenceValue);
+    public function addReference($referenceType, $referenceValue)
+    {
+        $this->logger->addReference($referenceType, $referenceValue);
         return $this;
     }
 

--- a/src/Controllers/StatusController.php
+++ b/src/Controllers/StatusController.php
@@ -71,9 +71,8 @@ class StatusController extends Controller
         }
 
         $this->logger->setIdentifier(__METHOD__);
-        $this->logger->setReferenceType(Logger::PAYONE_REQUEST_REFERENCE);
-        $this->logger->setReferenceValue($txid);
-        $this->logger->critical('Controller.Status', $this->request->all());
+        $this->logger->addReference(Logger::PAYONE_REQUEST_REFERENCE,$txid);
+        $this->logger->debug('Controller.Status', $this->request->all());
 
         if ($this->request->get('key') != md5($this->config->get('key'))) {
             return;

--- a/src/Services/Api.php
+++ b/src/Services/Api.php
@@ -70,7 +70,7 @@ class Api
 
         $responseObject = AuthResponseFactory::create($response);
 
-        $this->logger->setReferenceValue($responseObject->getTransactionID());
+        $this->logger->addReference(Logger::PAYONE_REQUEST_REFERENCE, $responseObject->getTransactionID());
         $this->logger->debug('Api.' . $this->getCallAction(self::REQUEST_TYPE_AUTH), $response);
 
         return $responseObject;
@@ -89,7 +89,7 @@ class Api
         $response = $this->doLibCall((self::REQUEST_TYPE_PRE_AUTH), $requestParams);
         $responseObject = PreAuthResponseFactory::create($response);
 
-        $this->logger->setReferenceValue($responseObject->getTransactionID());
+        $this->logger->addReference(Logger::PAYONE_REQUEST_REFERENCE, $responseObject->getTransactionID());
         $this->logger->debug('Api.' . $this->getCallAction(self::REQUEST_TYPE_PRE_AUTH), $response);
 
         return $responseObject;
@@ -109,7 +109,7 @@ class Api
 
         $responseObject = ResponseFactory::create($response);
 
-        $this->logger->setReferenceValue($responseObject->getTransactionID());
+        $this->logger->addReference(Logger::PAYONE_REQUEST_REFERENCE, $responseObject->getTransactionID());
         $this->logger->debug('Api.' . $this->getCallAction(self::REQUEST_TYPE_REVERSAL), $response);
 
         return $responseObject;
@@ -129,7 +129,7 @@ class Api
 
         $responseObject = ResponseFactory::create($response);
 
-        $this->logger->setReferenceValue($responseObject->getTransactionID());
+        $this->logger->addReference(Logger::PAYONE_REQUEST_REFERENCE, $responseObject->getTransactionID());
         $this->logger->debug('Api.' . $this->getCallAction(self::REQUEST_TYPE_CAPTURE), $response);
 
         return $responseObject;
@@ -149,7 +149,7 @@ class Api
 
         $responseObject = ResponseFactory::create($response);
 
-        $this->logger->setReferenceValue($responseObject->getTransactionID());
+        $this->logger->addReference(Logger::PAYONE_REQUEST_REFERENCE, $responseObject->getTransactionID());
         $this->logger->debug('Api.' . $this->getCallAction(self::REQUEST_TYPE_AUTH), $response);
 
         return $responseObject;
@@ -167,7 +167,7 @@ class Api
 
         $responseObject = ResponseFactory::create($response);
 
-        $this->logger->setReferenceValue($responseObject->getTransactionID());
+        $this->logger->addReference(Logger::PAYONE_REQUEST_REFERENCE, $responseObject->getTransactionID());
         $this->logger->debug('Api.' . $this->getCallAction(self::REQUEST_TYPE_AUTH), $response);
 
         return $responseObject;
@@ -185,7 +185,7 @@ class Api
 
         $responseObject = ResponseFactory::create($response);
 
-        $this->logger->setReferenceValue($responseObject->getTransactionID());
+        $this->logger->addReference(Logger::PAYONE_REQUEST_REFERENCE, $responseObject->getTransactionID());
         $this->logger->debug('Api.' . $this->getCallAction(self::REQUEST_TYPE_AUTH), $response);
 
         return $responseObject;
@@ -203,7 +203,7 @@ class Api
 
         $responseObject = ManagemandateResponseFactory::create($response);
 
-        $this->logger->setReferenceValue($responseObject->getTransactionID());
+        $this->logger->addReference(Logger::PAYONE_REQUEST_REFERENCE, $responseObject->getTransactionID());
         $this->logger->debug('Api.' . $this->getCallAction(self::REQUEST_TYPE_MANAGEMANDATE), $response);
 
         return $responseObject;
@@ -217,7 +217,6 @@ class Api
      */
     public function doLibCall($call, $requestParams): array
     {
-        $this->logger->setReferenceType(Logger::PAYONE_REQUEST_REFERENCE);
         $this->logger->debug('Api.' . $this->getCallAction($call), $requestParams);
 
         try {


### PR DESCRIPTION
@plentymarkets/team-order-payment 

https://plentymarkets.kanbanize.com/ctrl_board/50/cards/98515/details/

Das Logging der Request und Responses wurde einmal aufgeräumt (debug anstelle von critical)
Alte Logging-Funktion entfernt, die als deprecated markiert wurde