### PR TITLE
add order item properties logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 phpunit.ini
 /build/
 /.phan/
+.legacySyncTrace

--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,5 +1,10 @@
 # Release Notes für PAYONE
 
+## 2.1.0
+
+### Hinzugefügt
+- Bestellmerkmale können nun korrekt verarbeitet werden.
+
 ## 2.0.0
 
 ### TODO

--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -3,7 +3,7 @@
 ## 2.1.0
 
 ### Hinzugefügt
-- Bestellmerkmale können nun korrekt verarbeitet werden.
+- Bestelleigenschaften können nun korrekt verarbeitet werden.
 
 ## 2.0.0
 

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,5 +1,10 @@
 # Release Notes for PAYONE
 
+## 2.1.0
+
+### Added
+- Order item properties can now be processed correctly.
+
 ## 2.0.0
 
 ### TODO

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -3,7 +3,7 @@
 ## 2.1.0
 
 ### Added
-- Order item properties can now be processed correctly.
+- Order item order properties can now be processed correctly.
 
 ## 2.0.0
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "pluginIcon": "icon_plugin_xs.png",
   "price": 0.0,

--- a/src/PluginConstants.php
+++ b/src/PluginConstants.php
@@ -5,5 +5,5 @@ namespace Payone;
 class PluginConstants
 {
     const NAME = 'Payone';
-    const VERSION = '2.0.0';
+    const VERSION = '2.1.0';
 }

--- a/src/Providers/Api/Request/DataProviderAbstract.php
+++ b/src/Providers/Api/Request/DataProviderAbstract.php
@@ -230,8 +230,6 @@ abstract class DataProviderAbstract
                     foreach ($itemProperties as $itemProperty) {
                         $basketItemArr = [];
                         $basketItemArr['name'] = $basketItem->variationId . '_' . $itemProperty->id;
-                        $basketItemArr['price'] = (int)round($basketItemVariationProperty->price * 100);
-                        $basketItemArr['vat'] = (int)$basketItemVariationProperty->vat;
 
                         $price = $itemProperty->surcharge;
                         $property = $itemProperty->property;

--- a/src/Providers/Api/Request/DataProviderAbstract.php
+++ b/src/Providers/Api/Request/DataProviderAbstract.php
@@ -25,6 +25,8 @@ use Plenty\Modules\Frontend\Session\Storage\Contracts\FrontendSessionStorageFact
 use Plenty\Modules\Item\Item\Contracts\ItemRepositoryContract;
 use Plenty\Modules\Item\Item\Models\Item;
 use Plenty\Modules\Item\Item\Models\ItemText;
+use Plenty\Modules\Item\Variation\Contracts\VariationRepositoryContract;
+use Plenty\Modules\Item\Variation\Models\Variation;
 use Plenty\Modules\Order\Models\Order;
 use Plenty\Modules\Order\Models\OrderItem;
 use Plenty\Modules\Order\Models\OrderItemType;
@@ -33,6 +35,9 @@ use Plenty\Modules\Order\Shipping\ParcelService\Models\ParcelServicePreset;
 use Plenty\Modules\Payment\Contracts\PaymentRepositoryContract;
 use Plenty\Modules\Payment\Models\Payment;
 use Plenty\Modules\Payment\Models\PaymentProperty;
+use Plenty\Modules\Webshop\Contracts\LocalizationRepositoryContract;
+use Plenty\Modules\Webshop\Contracts\WebstoreConfigurationRepositoryContract;
+use Plenty\Modules\Item\Property\Models\Property;
 
 /**
  * Class DataProviderAbstract
@@ -167,19 +172,93 @@ abstract class DataProviderAbstract
         if (!$basket->basketItems) {
             return $items;
         }
+
+        /** @var VariationRepositoryContract $variationContract */
+        $variationContract = pluginApp(VariationRepositoryContract::class);
+        /** @var WebstoreConfigurationRepositoryContract $webstoreConfigurationRepository */
+        $webstoreConfigurationRepository = pluginApp(WebstoreConfigurationRepositoryContract::class);
+        $webstoreConfiguration = $webstoreConfigurationRepository->getWebstoreConfiguration();
+
+        /** @var LocalizationRepositoryContract $localizationRepository */
+        $localizationRepository = pluginApp(LocalizationRepositoryContract::class);
+        $language         = $localizationRepository->getLanguage();
+
         /** @var BasketItem $basketItem */
         foreach ($basket->basketItems as $basketItem) {
-            /** @var Item $item */
-            $item = $this->itemRepo->show($basketItem->itemId);
-            /** @var ItemText $itemText */
-            $itemText = $item->texts;
 
-            $basketItemArr = $basketItem->toArray();
-            $basketItemArr['name'] = $itemText->first()->name1;
-            $basketItemArr['price'] = (int)round($basketItem->price * 100);
-            $basketItemArr['vat'] = (int)$basketItem->vat;
+            if($basketItem->itemType != BasketItem::BASKET_ITEM_TYPE_VARIATION_ORDER_PROPERTY) {
+                /** @var Item $item */
+                $item = $this->itemRepo->show($basketItem->itemId);
+                /** @var ItemText $itemText */
+                $itemText = $item->texts;
 
-            $items[] = $basketItemArr;
+                $basketItemArr = $basketItem->toArray();
+                $basketItemArr['name'] = $itemText->first()->name1;
+                $basketItemArr['price'] = (int)round($basketItem->price * 100);
+                $basketItemArr['vat'] = (int)$basketItem->vat;
+
+                $items[] = $basketItemArr;
+            }
+
+            if($webstoreConfiguration->useVariationOrderProperties) {
+                foreach ($basketItem->basketItemVariationProperties as $basketItemVariationProperty) {
+                    if($basketItemVariationProperty instanceof BasketItem) {
+                        $basketItemArr = [];
+                        $reference = $basketItem->variationId;
+                        $name = $itemText->first()->name1;
+                        foreach ($basketItemVariationProperty->basketItemOrderParams as $basketItemOrderParam) {
+                            $reference .= '_'.$basketItemOrderParam->basketItemId;
+                            $name .= ' '.$basketItemOrderParam->value;
+                        }
+
+                        $basketItemArr['name'] = $name;
+                        $basketItemArr['price'] = (int)round($basketItemVariationProperty->price * 100);
+                        $basketItemArr['vat'] = (int)$basketItemVariationProperty->vat;
+                        $items[] = $basketItemArr;
+                    }
+                }
+            } else {
+                /**
+                 * Item property handling for surcharges
+                 * For example "Pfand"
+                 */
+                /** @var Variation $variation */
+                $variation = $variationContract->findById($basketItem->variationId);
+
+                $itemProperties = $variation->item->itemProperties;
+                if ($itemProperties && count($itemProperties) > 0) {
+                    foreach ($itemProperties as $itemProperty) {
+                        $basketItemArr = [];
+                        $basketItemArr['name'] = $basketItem->variationId . '_' . $itemProperty->id;
+                        $basketItemArr['price'] = (int)round($basketItemVariationProperty->price * 100);
+                        $basketItemArr['vat'] = (int)$basketItemVariationProperty->vat;
+
+                        $price = $itemProperty->surcharge;
+                        $property = $itemProperty->property;
+                        if ($property instanceof Property) {
+                            if(!$property->isOderProperty && $property->isShownAsAdditionalCosts) {
+                                $name = $property->names->first()->name;
+                                foreach ($property->names as $propertyName) {
+                                    if ($propertyName->lang == $language) {
+                                        $name = $propertyName->name;
+                                    }
+                                }
+                                $basketItemArr['name'] = $name;
+
+                                $markup = $property->surcharge;
+                                if($property->propertyGroupId > 0 && $property->group->first()->isSurchargePercental) {
+                                    $markup = $price / 100 * $property->surcharge;
+                                }
+                                $price += $markup;
+
+                                $basketItemArr['price'] = (int)round($price * 100);
+                                $basketItemArr['vat'] = (int)$basketItem->vat;
+                            }
+                        }
+                        $items[] = $basketItemArr;
+                    }
+                }
+            }
         }
 
         return $items;


### PR DESCRIPTION
### Description of the feature/fix:

Add missing order item properties logic. For the old and new logic. 

### Requirements that must be fulfilled:
- [x] New version in `plugin.json` updated
- [x] Changelog entry added
- [x] Plugin can be built (`build-set`)
- [x] Tested by the author
- [x] Tested by a second person


@plentymarkets/team-order-payment
____________________
New version must be uploaded from PID 31920.

Further information about the plugin can be found in the [Wiki](https://wiki.plentymarkets.com/display/OP/Payone).
