### PR TITLE
fix displaying credit card types

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,6 +1,11 @@
 # Release Notes für PAYONE
 
-## 2.2.1
+## 2.1.2
+
+### Behoben
+- Die erlaubten Arten von Kreditkarten wurden nicht korrekt dargestellt. Dies wurde nun behoben.
+
+## 2.1.1
 
 ### Behoben
 - Durch eine fehlerhafte Konfiguration des Plugins konnte es Fehler im Webshop geben, dies wurde behoben.  

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,6 +1,11 @@
 # Release Notes for PAYONE
 
-## 2.2.1
+## 2.1.2
+
+### Fixed
+- The allowed types of credit cards were not displayed correctly. This has now been fixed.
+
+## 2.1.1
 
 ### Fixed
 - Due to a faulty configuration of the plugin there could be errors in the webshop, this has been fixed.

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.1",
+  "version": "2.1.2",
   "license": "MIT",
   "pluginIcon": "icon_plugin_xs.png",
   "price": 0.0,

--- a/src/Models/CreditcardTypes.php
+++ b/src/Models/CreditcardTypes.php
@@ -39,7 +39,7 @@ class CreditcardTypes
     public function getAllowedTypes(): array
     {
         $allowedTypesFromConfig = $this->settingsService->getPaymentSettingsValue('AllowedCardTypes',PayoneCCPaymentMethod::PAYMENT_CODE);
-        if(!is_array($allowedTypesFromConfig)) {
+        if(is_array($allowedTypesFromConfig)) {
             return $allowedTypesFromConfig;
         }
         return [];


### PR DESCRIPTION
### Description of the feature/fix:
@plentymarkets/team-order-payment 

### Requirements that must be fulfilled:
- [x] New version in `plugin.json` updated
- [x] Changelog entry added
- [x] Plugin can be built (`build-set`)
- [x] Tested by the author
- [x] Tested by a second person


[Kanbanize Card](https://plentymarkets.kanbanize.com/ctrl_board/50/cards/191398/details/)

@plentymarkets/team-order-payment
____________________
New version must be uploaded from PID 31920.

Further information about the plugin can be found in the [Wiki](https://wiki.plentymarkets.com/display/OP/Payone).
