### PR TITLE
fix undefined fields for secure invoices

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,5 +1,10 @@
 # Release Notes für PAYONE
 
+## 2.3.1
+
+### Behoben
+- Beim gesichteren Rechnungskauf in Verbindung mit Merkmalen/Bestellmerkmalen/Bestelleigenschaften konnte es zu einem Fehler kommen. Dieser wurde behoben. 
+
 ## 2.3.0
 
 ### Hinzugefügt

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,5 +1,10 @@
 # Release Notes for PAYONE
 
+## 2.3.1
+
+### Fixed
+- An error could occur in the case of secure invoice purchase in connection with order item properties or item properties. This has been fixed.
+
 ## 2.3.0
 
 ### Added

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "MIT",
   "pluginIcon": "icon_plugin_xs.png",
   "price": 0.0,

--- a/src/PluginConstants.php
+++ b/src/PluginConstants.php
@@ -5,5 +5,5 @@ namespace Payone;
 class PluginConstants
 {
     const NAME = 'Payone';
-    const VERSION = '2.3.0';
+    const VERSION = '2.3.1';
 }

--- a/src/Providers/Api/Request/DataProviderAbstract.php
+++ b/src/Providers/Api/Request/DataProviderAbstract.php
@@ -233,6 +233,8 @@ abstract class DataProviderAbstract
                         $basketItemArr['itemId'] = $basketItem->variationId . '_' . $itemProperty->id;
                         $basketItemArr['quantity'] = 1;
                         $basketItemArr['name'] = $basketItem->variationId . '_' . $itemProperty->id;
+                        $basketItemArr['price'] = 0;
+                        $basketItemArr['vat'] = 0;
 
                         $price = $itemProperty->surcharge;
                         $property = $itemProperty->property;


### PR DESCRIPTION
### Description of the feature/fix:


### Requirements that must be fulfilled:
- [x] New version in `plugin.json` updated
- [x] Changelog entry added
- [x] Plugin can be built (`build-set`)
- [x] Tested by the author
- [ ] Tested by a second person


[Kanbanize Card](https://plentymarkets.kanbanize.com/ctrl_board/50/cards/219989/details/)

@plentymarkets/team-order-payment
____________________
New version must be uploaded from PID 31920.

Further information about the plugin can be found in the [Wiki](https://wiki.plentymarkets.com/display/OP/Payone).
