### PR TITLE
Add option to use individual payment icons for each payment method

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,5 +1,10 @@
 # Release Notes für PAYONE
 
+## X.X.X
+
+### Hinzugefügt
+- Im Assistenten kann nun für jede Zahlungsart ein individuelles Icon für den Webshop hinterlegt werden.
+
 ## 2.3.1
 
 ### Behoben

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,5 +1,10 @@
 # Release Notes for PAYONE
 
+## X.X.X
+
+### Added
+- In the assistant, an individual icon for each payment method can now be stored for the webshop.
+
 ## 2.3.1
 
 ### Fixed

--- a/resources/lang/de/Assistant.properties
+++ b/resources/lang/de/Assistant.properties
@@ -92,6 +92,8 @@ descriptionPayonePaymentSectionAmazonPay=Um die Zahlungsart Amazon Pay nutzen zu
 allowedDeliveryCountries=Lieferländer
 MinimumAmount=Gib einen Mindestbetrag für Käufe mit dieser Zahlungsart ein.
 MaximumAmount=Gib einen Maximalbetrag für Käufe mit dieser Zahlungsart ein.
+paymentIcon=Zahlungsarten-Icon für den Webshop
+paymentIconDescription=Icon der Zahlungsart
 
 ## Delivery Country names
 deliveryCountryDE=Deutschland

--- a/resources/lang/en/Assistant.properties
+++ b/resources/lang/en/Assistant.properties
@@ -90,6 +90,8 @@ descriptionPayonePaymentSectionAmazonPay=In order to use the payment method Amaz
 allowedDeliveryCountries=Delivery countries
 MinimumAmount=Enter a minimum amount for purchases with this payment method.
 MaximumAmount=Enter a maximum amount for purchases with this payment method.
+paymentIcon=Payment icon for the webshop
+paymentIconDescription=Payment icon
 
 ## Delivery Country names
 deliveryCountryDE=Germany

--- a/src/Assistants/DataSources/AssistantDataSource.php
+++ b/src/Assistants/DataSources/AssistantDataSource.php
@@ -142,6 +142,7 @@ class AssistantDataSource extends BaseWizardDataSource
                     $assistant[$paymentCode . 'Toggle'] = (bool)($value['active'] ?? false);
                     $assistant[$paymentCode . 'MinimumAmount'] = $value['MinimumAmount'] ?? 0;
                     $assistant[$paymentCode . 'MaximumAmount'] = $value['MaximumAmount'] ?? 2000;
+                    $assistant[$paymentCode . 'paymentIcon'] = $value['paymentIcon'];
                     $assistant[$paymentCode . 'AllowedDeliveryCountries'] = is_array($value['AllowedDeliveryCountries']) ? $value['AllowedDeliveryCountries'] : [];
                     $assistant[$paymentCode . 'AuthType'] = $value['AuthType'] ?? -1;
 

--- a/src/Assistants/PayoneAssistant.php
+++ b/src/Assistants/PayoneAssistant.php
@@ -249,7 +249,8 @@ class PayoneAssistant extends WizardProvider
                                 $this->getDeliveryCountriesConfig($paymentCode)
                                     +
                                 $this->getAuthorizationConfig($paymentCode)
-                        ]
+                        ],
+                        $this->getPaymentIconConfig($paymentCode)
                     ]
                 ];
             }
@@ -296,7 +297,8 @@ class PayoneAssistant extends WizardProvider
                             ]
                         ]
                     ]
-                ]
+                ],
+                $this->getPaymentIconConfig($paymentCode)
             ]
         ];
 
@@ -368,7 +370,8 @@ class PayoneAssistant extends WizardProvider
                             ]
                         ]
                     ]
-                ]
+                ],
+                $this->getPaymentIconConfig($paymentCode)
             ]
         ];
 
@@ -417,7 +420,8 @@ class PayoneAssistant extends WizardProvider
                                 ]
                             ]
                         ]
-                ]
+                ],
+                $this->getPaymentIconConfig($paymentCode)
             ]
         ];
 
@@ -511,6 +515,30 @@ class PayoneAssistant extends WizardProvider
                 'options' => [
                     'name' => 'Assistant.authType',
                     'listBoxValues' => $listBoxValues
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @param string $paymentCode
+     * @return array
+     */
+    protected function getPaymentIconConfig(string $paymentCode): array
+    {
+        return [
+            'description' => 'Assistant.paymentIcon',
+            'form'        => [
+                $paymentCode . "paymentIcon" => [
+                    'type' => 'file',
+                    'options' => [
+                        'name' => 'Assistant.paymentIconDescription',
+                        'showPreview' => true,
+                        'allowedExtensions' => [
+                            'svg', 'png', 'jpg', 'jpeg'
+                        ],
+                        'allowFolders' => false
+                    ]
                 ]
             ]
         ];

--- a/src/Assistants/SettingsHandlers/AssistantSettingsHandler.php
+++ b/src/Assistants/SettingsHandlers/AssistantSettingsHandler.php
@@ -66,6 +66,7 @@ class AssistantSettingsHandler implements WizardSettingsHandler
                 $payoneMethods[$paymentCode]['MaximumAmount'] = (int)($data[$paymentCode.'MaximumAmount'] ?? 0);
                 $payoneMethods[$paymentCode]['AllowedDeliveryCountries'] = is_array($data[$paymentCode.'AllowedDeliveryCountries']) ? $data[$paymentCode.'AllowedDeliveryCountries'] : [];
                 $payoneMethods[$paymentCode]['AuthType'] = (int)($data[$paymentCode.'AuthType'] ?? -1);
+                $payoneMethods[$paymentCode]['paymentIcon'] = $data[$paymentCode . 'paymentIcon'] ?? '';
             }
         }
 

--- a/src/Methods/PaymentAbstract.php
+++ b/src/Methods/PaymentAbstract.php
@@ -81,9 +81,14 @@ abstract class PaymentAbstract extends PaymentMethodBaseService
      */
     public function getIcon(string $lang = 'de'): string
     {
-        $pluginPath = $this->app->getUrlPath(PluginConstants::NAME);
+        $paymentIcon = $this->settingsService->getPaymentSettingsValue('paymentIcon', $this::PAYMENT_CODE);
 
-        return $pluginPath . '/images/logos/' . $this::PAYMENT_CODE . '.png';
+        if(empty($paymentIcon)) {
+            $pluginPath = $this->app->getUrlPath(PluginConstants::NAME);
+            $paymentIcon = $pluginPath . '/images/logos/' . $this::PAYMENT_CODE . '.png';
+        }
+
+        return $paymentIcon;
     }
 
     /**


### PR DESCRIPTION
### Requirements that must be fulfilled:
- [ ] New version in `plugin.json` updated
- [x] Changelog entry added
- [x] Plugin can be built (`build-set`)
- [x] Tested by the author
- [ ] Tested by a second person


[Kanbanize Card](https://plentymarkets.kanbanize.com/ctrl_board/75/cards/224088/details/)

@plentymarkets/team-order-payment
____________________
New version must be uploaded from PID 31920.

Further information about the plugin can be found in the [Wiki](https://wiki.plentymarkets.com/display/OP/Payone).
