### PR TITLE
fix php8 error

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,5 +1,11 @@
 # Release Notes für PAYONE
 
+## 2.5.2
+
+### Behoben
+- Wenn es bei einer Rückerstattung zu einem Fehler kam wurde dieser nicht korrekt dargestellt.
+- Fehler bei der Rückerstattung behoben.
+
 ## 2.5.1
 
 ### Behoben

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,5 +1,11 @@
 # Release Notes for PAYONE
 
+## 2.5.2
+
+### Fixed
+- If there was an error during a refund, it was not displayed correctly.
+- Fixed the error that occurred during the refund.
+
 ## 2.5.1
 
 ### Fixed

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.5.1",
+  "version": "2.5.2",
   "license": "",
   "pluginIcon": "icon_plugin_xs.png",
   "price": 0.0,

--- a/resources/lib/PayoneApi/Lib/Version.php
+++ b/resources/lib/PayoneApi/Lib/Version.php
@@ -12,6 +12,6 @@ class Version
      */
     public static function getVersion()
     {
-        return 'v2.5.0';
+        return 'v2.5.2';
     }
 }

--- a/resources/lib/PayoneApi/Response/ResponseDataAbstract.php
+++ b/resources/lib/PayoneApi/Response/ResponseDataAbstract.php
@@ -19,11 +19,13 @@ class ResponseDataAbstract
             $propertyName = strtolower(substr($method->name, 3, 1)) . substr($method->name, 4);
 
             $value = $method->invoke($this);
-            if (method_exists($value, 'jsonSerialize')
-                && is_callable([$value, 'jsonSerialize'])) {
-                $value = $value->jsonSerialize();
+            if(is_object($value) || is_string($value)) {
+                if (method_exists($value, 'jsonSerialize')
+                    && is_callable([$value, 'jsonSerialize'])) {
+                    $value = $value->jsonSerialize();
+                }
+                $result[$propertyName] = $value;
             }
-            $result[$propertyName] = $value;
         }
 
         return $result;


### PR DESCRIPTION
Fix php8 error

`method_exists(): Argument #1 ($object_or_class) must be of type object|string, bool given`

@plentymarkets/oms-preprocessing 

[AB#28140](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/28140) / [AB#28700](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/28700) / [AB#29850](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/29850)