### PR TITLE
fix handle bool in a correct way

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,5 +1,10 @@
 # Release Notes für PAYONE
 
+## 2.5.3 (2022-10-27)
+
+### Behoben
+- Zahlungen können nun in allen Fällen wieder abgeschlossen werden.
+
 ## 2.5.2
 
 ### Behoben

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,5 +1,10 @@
 # Release Notes for PAYONE
 
+## 2.5.3 (2022-10-27)
+
+### Fixed
+- Payments can now be completed again in all cases.
+
 ## 2.5.2
 
 ### Fixed

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.5.2",
+  "version": "2.5.3",
   "license": "",
   "pluginIcon": "icon_plugin_xs.png",
   "price": 0.0,

--- a/resources/lib/PayoneApi/Lib/Version.php
+++ b/resources/lib/PayoneApi/Lib/Version.php
@@ -12,6 +12,6 @@ class Version
      */
     public static function getVersion()
     {
-        return 'v2.5.2';
+        return 'v2.5.3';
     }
 }

--- a/resources/lib/PayoneApi/Response/ResponseDataAbstract.php
+++ b/resources/lib/PayoneApi/Response/ResponseDataAbstract.php
@@ -25,6 +25,8 @@ class ResponseDataAbstract
                     $value = $value->jsonSerialize();
                 }
                 $result[$propertyName] = $value;
+            } elseif(is_bool($value)) {
+                $result[$propertyName] = $value;
             }
         }
 


### PR DESCRIPTION
### Description of the feature/fix:
Since PHP8 a boolean isn't a string anymore and the is_string function will return false in such a case.
Because of this there was a return value missing which is parsed as a bool. So we have to add an additional check if the value is a bool to also add it to the response array.

### Requirements that must be fulfilled:
- [x] New version in `plugin.json` updated
- [x] Changelog entry added
- [x] Plugin can be built (`build-set`)
- [x] Tested by the author
- [ ] Tested by a second person

[AB#31329](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/31329) / [AB#32236](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/32236)

@plentymarkets/oms-preprocessing 
_________________
New version must be uploaded from PID 31920.

Further information about the plugin can be found in the [Wiki](https://wiki.plentymarkets.com/display/OP/Payone).
