### PR TITLE
PayOne: Language of hint on invoices was always in german

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,5 +1,10 @@
 # Release Notes für PAYONE
 
+## 2.6.0 (TBA)
+
+### Behoben
+- Hinweistexte auf Rechnungsdokumenten werden nun in der entsprechenden Sprache aufgedruckt.
+
 ## 2.5.3 (2022-10-27)
 
 ### Behoben

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,5 +1,10 @@
 # Release Notes for PAYONE
 
+## 2.6.0 (TBA)
+
+### Fixed
+- Notes on invoice documents are now printed in the appropriate language.
+
 ## 2.5.3 (2022-10-27)
 
 ### Fixed

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.5.3",
+  "version": "2.6.0",
   "license": "",
   "pluginIcon": "icon_plugin_xs.png",
   "price": 0.0,

--- a/resources/lang/en/Invoice.properties
+++ b/resources/lang/en/Invoice.properties
@@ -1,4 +1,4 @@
-holder = "holder"
-iban = "iban"
-bic = "bic"
+holder = "Holder"
+iban = "Iban"
+bic = "Bic"
 paymentReference = "Payment reference"

--- a/resources/lib/PayoneApi/Lib/Version.php
+++ b/resources/lib/PayoneApi/Lib/Version.php
@@ -12,6 +12,6 @@ class Version
      */
     public static function getVersion()
     {
-        return 'v2.5.3';
+        return 'v2.6.0';
     }
 }

--- a/src/Services/OrderPdf.php
+++ b/src/Services/OrderPdf.php
@@ -50,8 +50,8 @@ class OrderPdf
         }
 
         $adviceData = [
-            (string)$this->getPayoneBankAccount($payment),
-            $this->getPaymentReferenceText($payment),
+            (string)$this->getPayoneBankAccount($payment, $lang),
+            $this->getPaymentReferenceText($payment, $lang),
         ];
 
         $orderPdfGenerationModel->advice = implode(self::PDF_LINEBREAK . self::PDF_LINEBREAK, $adviceData);
@@ -61,9 +61,10 @@ class OrderPdf
 
     /**
      * @param Payment $payment
+     * @param String $lang
      * @return string
      */
-    private function getPayoneBankAccount(Payment $payment): string
+    private function getPayoneBankAccount(Payment $payment, String $lang): string
     {
 
         $iban = $this->paymentHelper->getPaymentPropertyValue($payment, PaymentProperty::TYPE_IBAN_OF_RECEIVER);;
@@ -75,7 +76,7 @@ class OrderPdf
             return '';
         }
 
-        return $this->translator->trans('Invoice.holder') . ': ' . $accountHolder . self::PDF_LINEBREAK .
+        return $this->translator->trans('Invoice.holder', [], $lang) . ': ' . $accountHolder . self::PDF_LINEBREAK .
             'IBAN: ' . $iban . self::PDF_LINEBREAK .
             'BIC: ' . $bic;
     }
@@ -83,14 +84,15 @@ class OrderPdf
 
     /**
      * @param Payment $payment
+     * @param String $lang
      * @return string
      */
-    private function getPaymentReferenceText(Payment $payment): string
+    private function getPaymentReferenceText(Payment $payment, String $lang): string
     {
         $referenceNumber = $this->paymentHelper->getPaymentPropertyValue(
             $payment,
             PaymentProperty::TYPE_TRANSACTION_ID
         );
-        return $this->translator->trans('Invoice.paymentReference') . ': ' . $referenceNumber;
+        return $this->translator->trans('Invoice.paymentReference', [], $lang) . ': ' . $referenceNumber;
     }
 }


### PR DESCRIPTION
### Description of the feature/fix:
Language of hint on invoices was always in german

### Requirements that must be fulfilled:
- [x] New version in `plugin.json` updated
- [x] Changelog entry added
- [x] Plugin can be built (`build-set`)
- [x] Tested by the author
- [x] Tested by a second person


[AB#56134](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/56134)
[AB#55805](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/55805)

@plentymarkets/team-order-payment
____________________
New version must be uploaded from PID 31920.

Further information about the plugin can be found in the [Wiki](https://wiki.plentymarkets.com/display/OP/Payone).
